### PR TITLE
Fix typo, remove 'Bundle' from twig namespace

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -39,7 +39,7 @@ class DefaultController extends AbstractController
      */
     public function indexAction()
     {
-        return $this->render('@OpensoftRolloutBundle/Default/index.html.twig', array('rollout' => $this->rollout));
+        return $this->render('@OpensoftRollout/Default/index.html.twig', array('rollout' => $this->rollout));
     }
 
     /**

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{% extends "@OpensoftRolloutBundle/layout.html.twig" %}
+{% extends "@OpensoftRollout/layout.html.twig" %}
 
 {% block rollout_content %}
 <div class="page-header">


### PR DESCRIPTION
Fix typo, remove 'Bundle' from twig namespace